### PR TITLE
Remove empty line in 003 Readme

### DIFF
--- a/003-K8S-Cluster-Setup/README.md
+++ b/003-K8S-Cluster-Setup/README.md
@@ -83,7 +83,6 @@ The `LoadBalancer` type spins up a load balancer in GCP automatically.
 1. To expose the application we create a Service with the type of LoadBalancer:
 ```
 kubectl expose deployment link-unshorten --type=LoadBalancer
-
 ```
 
 2. We can now see our new Service details by running the following command:


### PR DESCRIPTION
This fixes an issue in some markdown renderers (like the one used by Atom)